### PR TITLE
fix: use -i flag for interactive bootstrap instead of piping yes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 {
   set -eo pipefail
 
-  trap 'rm -rf "$temp"' 0
+  trap 'rm -rf "$temp"' EXIT
   temp=$(mktemp -d)
   cd "$temp"
 
@@ -13,6 +13,6 @@
   if [[ -n "$CI" ]]; then
     ./install.sh
   else
-    yes | ./install.sh
+    ./install.sh -i
   fi
 }


### PR DESCRIPTION
## Summary

`bootstrap.sh` piped `yes` into `./install.sh` for non-CI environments, but `install.sh` only shows a confirmation prompt when the `-i` flag is passed. Without `-i`, the `yes` pipe had no effect and the installer ran non-interactively regardless.

## Changes

### `bootstrap.sh`

- **Fix**: Replace `yes | ./install.sh` with `./install.sh -i` so that bootstrap actually triggers interactive confirmation outside CI.
- **Cleanup**: Unify the `trap` signal from `0` to `EXIT` for consistency with `install.sh`.

## Before / After

```diff
-  trap 'rm -rf "$temp"' 0
+  trap 'rm -rf "$temp"' EXIT
```

```diff
-    yes | ./install.sh
+    ./install.sh -i
```

## Validation

- `bash -n bootstrap.sh` — syntax check passes
- `bash -n install.sh` — syntax check passes
- Reviewed that `install.sh` `-i` flag correctly triggers interactive confirmation (lines 19-27, 51-62)