### PR TITLE
fix: name interactive read target explicitly

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ if [[ "$interactive" = yes ]]; then
   cat "$sandbox/patch.diff" >&2
   echo >&2
   echo -n "Apply? (y/N): " >&2
-  read -r
+  read -r REPLY
   echo >&2
 
   if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
## Summary

Make the destination of the interactive installer input explicit by passing `REPLY` to `read`.

## Why

`read -r` stores input in `REPLY` implicitly when no variable name is supplied. Naming `REPLY` at the input site makes its relationship with the following condition explicit.

This addresses section 1.2 of the dotfiles improvement report.

## Changes

- Replace `read -r` with `read -r REPLY` in the interactive confirmation path of `install.sh`.
- Accept confirmation input with leading or trailing IFS whitespace, such as ` y `, because assigning to a named variable causes `read` to trim that whitespace before the value is checked.

## Validation

- `bash -n install.sh bootstrap.sh`
- `HOME="$(mktemp -d)" ./install.sh`
- `HOME="$(mktemp -d)" ./install.sh -i <<<"y"`
- `HOME="$(mktemp -d)" ./install.sh -i <<<' y '`