### PR TITLE
[codex] fix install sources outside repository cwd

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,18 @@ jobs:
       - run: |
           bash -c "$(curl -fsSL https://github.com/kou64yama/dotfiles/raw/$GITHUB_SHA/bootstrap.sh)"
 
+  regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run install.sh outside repo cwd
+        run: |
+          tmp_home="$(mktemp -d)"
+          trap 'rm -rf "$tmp_home"' EXIT
+          cd /tmp
+          HOME="$tmp_home" "$GITHUB_WORKSPACE/install.sh"
+
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 
 trap 'if [[ -n "$sandbox" ]]; then rm -rf "$sandbox"; fi' EXIT
 
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 sandbox=$(mktemp -d)
 files=(
   '0644 .gitconfig                                files/git/gitconfig.ini'
@@ -39,7 +40,7 @@ for file in "${files[@]}"; do
   if [[ ! -d "$sandbox/b/$dir" ]]; then
     mkdir -p "$sandbox/b/$dir"
   fi
-  cp "$src" "$sandbox/b/$path"
+  cp "$script_dir/$src" "$sandbox/b/$path"
   chmod "$mode" "$sandbox/b/$path"
 done
 


### PR DESCRIPTION
## Summary

- Resolve manifest source files relative to `install.sh` instead of the caller's current working directory.
- Add a CI regression job that runs the installer from `/tmp` with an isolated temporary `HOME`.

## Why

`install.sh` stored source paths such as `files/git/gitconfig.ini` in its manifest but passed them directly to `cp`. Running the script outside the repository root therefore failed because those paths were resolved from the caller's working directory.

This addresses section 1.3 of the dotfiles improvement report.

## Impact

The installer can now be invoked by absolute or relative path from any working directory. The manifest format and installed files are unchanged.

## Commits

- `fix(install): resolve sources relative to script root`
- `ci: test install outside repository root`

## Validation

- `bash -n install.sh bootstrap.sh`
- Isolated installation from the repository root
- Isolated installation from `/tmp` using the absolute `install.sh` path
- YAML parsing with Ruby
- `git diff --check main...HEAD`
- `podman build -t dotfiles:test .`
- Final review by the GPT-5.4-mini Driver: no findings