### PR TITLE
ci: add lint job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,13 @@ on:
       - main
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run ShellCheck
+        run: shellcheck install.sh bootstrap.sh
+
   bootstrap:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a `lint` job to the GitHub Action. It uses `shellcheck` to check `install.sh` and `bootstrap.sh`.