### PR TITLE
fix: add tmux and remove patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN echo skip_global_compinit=1 >> /etc/skel/.zshenv
 FROM ubuntu:24.04
 
 ARG PACKAGE_LIST='\
-  patch \
   git \
   neovim \
-'
+  tmux \
+  '
 RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt/archives,sharing=locked \
   apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl sudo zsh ${PACKAGE_LIST}


### PR DESCRIPTION
This PR adds `tmux` to the final stage of Docker and removes `patch`.

`tmux` was not installed despite deploying the configuration file.
`patch` is an unnecessary package for the final stage.
