### PR TITLE
feat(zsh): remove ripgrep aliases for grep

### DIFF
--- a/files/zsh/zshrc.zsh
+++ b/files/zsh/zshrc.zsh
@@ -157,16 +157,6 @@ if command -v bat >/dev/null 2>&1; then
 fi
 
 #
-# rg
-#
-
-if command -v rg >/dev/null 2>&1; then
-  alias grep='rg'
-  alias egrep='rg'
-  alias fgrep='rg -f'
-fi
-
-#
 # xh
 #
 


### PR DESCRIPTION
## Description
This PR removes the aliases that override `grep`, `egrep`, and `fgrep` with `rg` (ripgrep) in `files/zsh/zshrc.zsh`.
Since `rg` is not fully compatible with standard `grep` commands, this aliasing can cause confusion or unexpected behavior for AI agents that expect standard `grep`.

## User-visible Configuration Changes
- `grep`, `egrep`, and `fgrep` will no longer be aliased to `rg`. They will invoke standard system `grep` commands.

## Validation Commands
- Shell syntax check:
  ```bash
  bash -n install.sh bootstrap.sh
  ```
- Smoke-test installation in isolated `HOME`:
  ```bash
  HOME="$(mktemp -d)" ./install.sh
  ```