### PR TITLE
perf(zsh): cache mise completion

### DIFF
--- a/files/zsh/zshrc.zsh
+++ b/files/zsh/zshrc.zsh
@@ -1,3 +1,10 @@
+#
+# PATH
+#
+
+PATH=$HOME/.local/bin:$PATH
+fpath+=$HOME/.local/share/zsh/site-functions
+
 # Start configuration added by Zim Framework install {{{
 #
 # User configuration sourced by interactive shells
@@ -105,13 +112,16 @@ fi
 source ${ZIM_HOME}/init.zsh
 # }}} End configuration added by Zim Framework install
 
-#
 # Activate mise
 #
 
-if [[ -x ~/.local/bin/mise ]]; then
-  eval "$(~/.local/bin/mise activate zsh)"
-  eval "$(~/.local/bin/mise completion zsh)"
+if command -v mise >/dev/null 2>&1; then
+  eval "$(mise activate zsh)"
+
+  if [[ ! -f "${HOME}/.local/share/zsh/site-functions/_mise" ]]; then
+    mkdir -p "${HOME}/.local/share/zsh/site-functions"
+    mise completion zsh > "${HOME}/.local/share/zsh/site-functions/_mise"
+  fi
 fi
 
 #


### PR DESCRIPTION
## Description
This PR caches the `mise` shell completion output in `~/.local/share/zsh/site-functions/_mise` instead of executing `eval "$(mise completion zsh)"` on every shell startup. This improves Zsh interactive shell startup performance.

This addresses section 7.3 of the dotfiles improvement report.

## User-visible Configuration Changes
- `fpath` now includes `$HOME/.local/share/zsh/site-functions`.
- A cached completion file `_mise` is generated dynamically on first startup.

## Validation Commands
- Shell syntax check:
  ```bash
  bash -n install.sh bootstrap.sh
  ```
- Smoke-test installation in isolated `HOME`:
  ```bash
  HOME="$(mktemp -d)" ./install.sh
  ```
- Container build and Zsh startup test (with Podman):
  ```bash
  podman build -t dotfiles:test .
  podman run --rm dotfiles:test zsh -ic "ls -la ~/.local/share/zsh/site-functions/_mise"
  ```
