### PR TITLE
fix: Docker mise installation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,10 @@ jobs:
         with:
           load: true
           tags: ghcr.io/kou64yama/dotfiles:latest
+      - name: Smoke test mise version
+        run: |
+          version="$(docker run --rm ghcr.io/kou64yama/dotfiles:latest /home/dotfiles/.local/bin/mise --version)"
+          test "$(printf '%s\n' "$version" | awk '{print $1}')" = "2026.6.6"
       - name: Build and push
         if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:24.04 AS builder
 
+ARG TARGETARCH
+ARG MISE_VERSION=2026.6.6
+
 RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt/archives,sharing=locked \
   apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl patch
@@ -10,7 +13,20 @@ COPY install.sh ./
 COPY files/ ./files/
 
 ENV HOME=/etc/skel
-RUN curl https://mise.run | sh
+RUN set -eu; \
+  case "${TARGETARCH}" in \
+    amd64) mise_arch=x64; mise_sha=b8c25ad5e1c178bb7ba1e0fca9066153f8ef1b28bf5a8456c20a8acd2522e556 ;; \
+    arm64) mise_arch=arm64; mise_sha=e3482fc5dde76502c1714b85963da411698436f06fefef7b6f0ee16fd00136a0 ;; \
+    *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac; \
+  mise_tag=v${MISE_VERSION}; \
+  tmpdir="$(mktemp -d)"; \
+  trap 'rm -rf "$tmpdir"' EXIT; \
+  mkdir -p /etc/skel/.local/bin; \
+  curl -fsSL "https://github.com/jdx/mise/releases/download/${mise_tag}/mise-${mise_tag}-linux-${mise_arch}" -o "${tmpdir}/mise"; \
+  echo "${mise_sha}  ${tmpdir}/mise" | sha256sum -c -; \
+  install -m 0755 "${tmpdir}/mise" /etc/skel/.local/bin/mise; \
+  test "$(/etc/skel/.local/bin/mise --version | awk '{print $1}')" = "${MISE_VERSION}"
 RUN yes | ./install.sh
 RUN echo skip_global_compinit=1 >> /etc/skel/.zshenv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:24.04 AS builder
 
 ARG TARGETARCH
 ARG MISE_VERSION=2026.6.6
+ARG MISE_SHA256_AMD64=b8c25ad5e1c178bb7ba1e0fca9066153f8ef1b28bf5a8456c20a8acd2522e556
+ARG MISE_SHA256_ARM64=e3482fc5dde76502c1714b85963da411698436f06fefef7b6f0ee16fd00136a0
 
 RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt/archives,sharing=locked \
   apt-get update \
@@ -15,8 +17,8 @@ COPY files/ ./files/
 ENV HOME=/etc/skel
 RUN set -eu; \
   case "${TARGETARCH}" in \
-    amd64) mise_arch=x64; mise_sha=b8c25ad5e1c178bb7ba1e0fca9066153f8ef1b28bf5a8456c20a8acd2522e556 ;; \
-    arm64) mise_arch=arm64; mise_sha=e3482fc5dde76502c1714b85963da411698436f06fefef7b6f0ee16fd00136a0 ;; \
+    amd64) mise_arch=x64; mise_sha=${MISE_SHA256_AMD64} ;; \
+    arm64) mise_arch=arm64; mise_sha=${MISE_SHA256_ARM64} ;; \
     *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
   esac; \
   mise_tag=v${MISE_VERSION}; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,10 @@ RUN set -eu; \
     *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
   esac; \
   mise_tag=v${MISE_VERSION}; \
-  tmpdir="$(mktemp -d)"; \
-  trap 'rm -rf "$tmpdir"' EXIT; \
   mkdir -p /etc/skel/.local/bin; \
-  curl -fsSL "https://github.com/jdx/mise/releases/download/${mise_tag}/mise-${mise_tag}-linux-${mise_arch}" -o "${tmpdir}/mise"; \
-  echo "${mise_sha}  ${tmpdir}/mise" | sha256sum -c -; \
-  install -m 0755 "${tmpdir}/mise" /etc/skel/.local/bin/mise; \
+  curl -fsSL "https://github.com/jdx/mise/releases/download/${mise_tag}/mise-${mise_tag}-linux-${mise_arch}" -o /etc/skel/.local/bin/mise; \
+  echo "${mise_sha}  /etc/skel/.local/bin/mise" | sha256sum -c -; \
+  chmod 0755 /etc/skel/.local/bin/mise; \
   test "$(/etc/skel/.local/bin/mise --version | awk '{print $1}')" = "${MISE_VERSION}"
 RUN yes | ./install.sh
 RUN echo skip_global_compinit=1 >> /etc/skel/.zshenv


### PR DESCRIPTION
## What changed

- replace `curl https://mise.run | sh` with a pinned mise v2026.6.6 release binary
- select the official x64 or arm64 asset from BuildKit's `TARGETARCH`
- verify each asset against its pinned SHA-256 before installation
- fail the build for unsupported architectures or an unexpected mise version
- smoke-test the installed mise version in the built image in CI

## Why

Executing a mutable remote script directly during the image build creates an avoidable supply-chain risk. Pinning and verifying the release artifact makes the installation reproducible and ensures the downloaded binary is checked before execution.

## Validation

- `bash -n install.sh bootstrap.sh`
- isolated installation with `HOME="$(mktemp -d)" ./install.sh`
- `podman build --platform linux/arm64 -t dotfiles:test .`
- completed-image mise version smoke test on arm64
- amd64 build passed the mise download, checksum, and version-verification stages; the local Podman VM later stopped in the final stage with an overlay storage mount error
- `git diff --check`
- GitHub Actions YAML parse