### PR TITLE
feat: extract dotfiles manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/
 
 WORKDIR /workspace
 
-COPY install.sh ./
+COPY install.sh manifest.txt ./
 COPY files/ ./files/
 
 ENV HOME=/etc/skel

--- a/install.sh
+++ b/install.sh
@@ -6,15 +6,6 @@ trap 'if [[ -n "$sandbox" ]]; then rm -rf "$sandbox"; fi' EXIT
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 sandbox=$(mktemp -d)
-files=(
-  '0644 .gitconfig                                files/git/gitconfig.ini'
-  '0644 .zshrc                                    files/zsh/zshrc.zsh'
-  '0644 .zimrc                                    files/zsh/zimrc.zsh'
-  '0644 .tmux.conf                                files/tmux/tmux.conf'
-  '0644 .config/nvim/init.lua                     files/nvim/init.lua'
-  '0644 .config/nvim/lua/config/lazy.lua          files/nvim/lua/config/lazy.lua'
-  '0644 .config/nvim/lua/plugins/statusline.lua   files/nvim/lua/plugins/statusline.lua'
-)
 interactive=no
 
 while getopts i OPT; do
@@ -28,13 +19,21 @@ while getopts i OPT; do
 done
 shift $((OPTIND - 1))
 
+while read -r line; do
+  if [[ "$line" =~ ^# ]] || [[ "$line" =~ ^[\ \t]*$ ]]; then
+    continue
+  fi
+
+  manifest+=("$line")
+done <"$script_dir/manifest.txt"
+
 mkdir -p "$sandbox/a"
 if [[ -f "$HOME/.local/var/dotfiles.tgz" ]]; then
   tar -xf "$HOME/.local/var/dotfiles.tgz" -C "$sandbox/a"
 fi
 
 mkdir -p "$sandbox/b"
-for file in "${files[@]}"; do
+for file in "${manifest[@]}"; do
   IFS=' ' read -r mode path src <<<"$file"
   dir=$(dirname "$path")
   if [[ ! -d "$sandbox/b/$dir" ]]; then

--- a/manifest.txt
+++ b/manifest.txt
@@ -1,0 +1,14 @@
+# Git
+0644 .gitconfig files/git/gitconfig.ini
+
+# Zsh
+0644 .zshrc files/zsh/zshrc.zsh
+0644 .zimrc files/zsh/zimrc.zsh
+
+# Tmux
+0644 .tmux.conf files/tmux/tmux.conf
+
+# NeoVim
+0644 .config/nvim/init.lua                    files/nvim/init.lua
+0644 .config/nvim/lua/config/lazy.lua         files/nvim/lua/config/lazy.lua
+0644 .config/nvim/lua/plugins/statusline.lua  files/nvim/lua/plugins/statusline.lua


### PR DESCRIPTION
## Summary

- move the dotfile installation manifest out of `install.sh` into `manifest.txt`
- allow comments and blank lines in the manifest for tool-based grouping
- include `manifest.txt` in the Docker build context

## Why

Keeping the file list in a standalone manifest makes dotfile additions easier to review and maintain without editing installer logic.

## Impact

Installation behavior remains unchanged. The installer now reads mode, destination, and source entries from `manifest.txt`, skipping comments and blank lines.

## Validation

- `bash -n install.sh bootstrap.sh`
- `HOME="$(mktemp -d)" ./install.sh`
- `git diff --check origin/main...HEAD`

`docker build -t dotfiles:test .` was not run because Docker is not installed in the local environment.