### PR TITLE
docs(git): document local user settings

### DIFF
--- a/files/git/gitconfig.ini
+++ b/files/git/gitconfig.ini
@@ -1,4 +1,7 @@
 [user]
+  # Machine-specific user settings should be configured in ~/.gitconfig.local
+  # name = Your Name
+  # email = your@email.example
 
 [core]
 


### PR DESCRIPTION
## Summary

- document that machine-specific Git user settings belong in `~/.gitconfig.local`
- add commented examples for `user.name` and `user.email`

## Impact

This makes the intended local identity configuration discoverable without changing installed Git behavior.

## Validation

- `bash -n install.sh bootstrap.sh`
- `HOME="$(mktemp -d)" ./install.sh`