### PR TITLE
feat(nvim): add basic Neovim options

### DIFF
--- a/files/nvim/init.lua
+++ b/files/nvim/init.lua
@@ -1,1 +1,2 @@
+require("config.options")
 require("config.lazy")

--- a/files/nvim/lua/config/options.lua
+++ b/files/nvim/lua/config/options.lua
@@ -1,0 +1,17 @@
+vim.opt.number = true
+
+vim.opt.clipboard:append("unnamedplus")
+
+vim.opt.ignorecase = true
+vim.opt.smartcase = true
+
+vim.opt.expandtab = true
+vim.opt.shiftwidth = 4
+vim.opt.tabstop = 4
+vim.opt.smartindent = true
+
+vim.opt.termguicolors = true
+vim.opt.cursorline = true
+vim.opt.signcolumn = "yes"
+
+vim.cmd.colorscheme("habamax")

--- a/manifest.txt
+++ b/manifest.txt
@@ -10,5 +10,6 @@
 
 # NeoVim
 0644 .config/nvim/init.lua                    files/nvim/init.lua
+0644 .config/nvim/lua/config/options.lua      files/nvim/lua/config/options.lua
 0644 .config/nvim/lua/config/lazy.lua         files/nvim/lua/config/lazy.lua
 0644 .config/nvim/lua/plugins/statusline.lua  files/nvim/lua/plugins/statusline.lua


### PR DESCRIPTION
## Summary

- load a dedicated `config.options` module before lazy.nvim
- configure line numbers, system clipboard integration, case-aware search, indentation, and the built-in `habamax` colorscheme
- register the new options module in the dotfiles manifest

## Why

The Neovim configuration only defined the statusline plugin and lacked baseline editor behavior. This addresses section 6.2 of the improvement report without adding another plugin dependency.

## Impact

Installed Neovim environments now receive consistent basic editing defaults and a colorscheme.

## Validation

- `bash -n install.sh bootstrap.sh`
- `git diff --check origin/main...HEAD`
- isolated installation with `HOME="$(mktemp -d)" ./install.sh`
- Neovim headless assertions for all configured options and the `habamax` colorscheme