### PR TITLE
fix(bootstrap): bootstrap revision handling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,13 @@ jobs:
   bootstrap:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          bash -c "$(curl -fsSL https://github.com/kou64yama/dotfiles/raw/$GITHUB_SHA/bootstrap.sh)"
+      - env:
+          BOOTSTRAP_REVISION: ${{ github.sha }}
+        run: |
+          bootstrap="$(mktemp)"
+          trap 'rm -f "$bootstrap"' EXIT
+          curl -fsSL --progress-bar "https://github.com/kou64yama/dotfiles/raw/${BOOTSTRAP_REVISION}/bootstrap.sh" -o "$bootstrap"
+          bash "$bootstrap" "$BOOTSTRAP_REVISION"
 
   regression:
     runs-on: ubuntu-latest

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,8 @@
   temp=$(mktemp -d)
   cd "$temp"
 
-  tarball=https://github.com/kou64yama/dotfiles/archive/${GITHUB_SHA:-main}.tar.gz
+  revision=${1:-${GITHUB_SHA:-main}}
+  tarball=https://github.com/kou64yama/dotfiles/archive/${revision}.tar.gz
   curl -fsSL --progress-bar "$tarball" | tar --strip-components=1 -xz
 
   if [[ -n "$CI" ]]; then


### PR DESCRIPTION
## Summary

- allow `bootstrap.sh` callers to pass an explicit repository revision
- pin the bootstrap CI job to `${{ github.sha }}`
- download and execute `bootstrap.sh` from the same revision used for the archive

## Why

The bootstrap job relied on the implicit `GITHUB_SHA` environment variable while `bootstrap.sh` retained a `main` fallback. That made the revision contract indirect and allowed the downloaded script and archive selection to diverge if the environment was missing or changed.

The workflow now selects the tested revision explicitly, downloads `bootstrap.sh` from that SHA, and passes the same SHA as the script's first argument. Existing user-facing invocations remain compatible through the `GITHUB_SHA` and `main` fallbacks.

For `pull_request` workflows, `${{ github.sha }}` intentionally identifies GitHub's merge commit, so the bootstrap job tests the revision represented by the workflow run.

## Commits

- `fix(bootstrap): accept an explicit revision`
- `ci: pin bootstrap job to tested revision`

## Validation

- `bash -n install.sh bootstrap.sh`
- Ruby YAML parse of `.github/workflows/build.yaml`
- `git diff --check main...HEAD`
- isolated installation with an explicit `origin/main` SHA
- end-to-end remote bootstrap using the pushed head SHA for both the script and archive
- GPT-5.4-mini Driver final review: no findings

ShellCheck is not installed locally; the existing CI lint job will run it.