### PR TITLE
fix(tmux): pin tpm version to v3.1.0 on auto clone

### DIFF
--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -21,7 +21,7 @@ set -g @dracula-show-powerline true
 set -g @dracula-show-timezone false
 
 if "test ! -d ~/.tmux/plugins/tpm" \
-   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
+   "run 'git clone -b v3.1.0 --depth 1 https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
 
 run '~/.tmux/plugins/tpm/tpm'
 


### PR DESCRIPTION
Addresses section 2.3 of the improvement report by pinning the cloned `tmux-plugins/tpm` repository to a specific stable tag (`v3.1.0`) with `--depth 1`.