### PR TITLE
fix(git): remove ssh to https url redirection

### DIFF
--- a/files/git/gitconfig.ini
+++ b/files/git/gitconfig.ini
@@ -25,6 +25,3 @@
 	smudge = git-lfs smudge -- %f
 	process = git-lfs filter-process
 	required = true
-
-[url "https://github.com/"]
-	insteadOf = "git@github.com:"


### PR DESCRIPTION
This setting is unnecessary and will be deleted.